### PR TITLE
Fix typo in A/L 2022 link homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -263,10 +263,10 @@ d.js doesn't work if you view the page via file:// -->
 				<div class="col-md-4 col-sm-4 no-padd">
 					<div class="feature-box4 padd-30 bg-dark-blue no-margin">
 						<i class="icon icon-envelope"></i>
-						<h4>2020 A/L Application</h4>
-						<p>To download the 2020 Advanced level application, Please visit the following page.</p>
-						<a href="apps/AL_2020/index.html"
-						   class="btn radial btn-dark-blue hvr-icon-wobble-horizontal">Download</a>
+						<h4>2022 A/L Application</h4>
+						<p>To download the 2022 Advanced level application, Please visit the following page.</p>
+						<a href="apps/AL_2022/index.html"
+						   class="btn radial btn-blue hvr-icon-wobble-horizontal">Download</a>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix #96 

## Goals
To fix typing error in homepage

## Approach
Changed "2020" to "2022" 

### Screenshots
![Screenshot from 2020-05-14 14-40-53](https://user-images.githubusercontent.com/60275681/81916021-f1d24380-95f0-11ea-8afc-1078c4682f8c.png)
  

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
