### PR TITLE
Temporarily hide "Principals" link in footer

### DIFF
--- a/assets/content/footer.html
+++ b/assets/content/footer.html
@@ -47,9 +47,6 @@
                         <a href="https://www.sack.edu.lk/anthem.html">Anthem</a>
                     </li>
                     <li><i class="fa fa-angle-right"></i>
-                        <a href="principals.html">Principals</a>
-                    </li>
-                    <li><i class="fa fa-angle-right"></i>
                         <a href="https://www.sack.edu.lk/head_prefects.html">Head Prefects </a>
                     </li>
                     <li><i class="fa fa-angle-right"></i>


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix #137

## Goals
Remove unwanted links

## Approach
Remove "Principals" list item in footer


### Screenshots
![Screenshot from 2020-07-16 14-15-56](https://user-images.githubusercontent.com/62067185/87652656-21790580-c772-11ea-9b01-c549d66dcecc.png)
⇩⇩⇩⇩⇩⇩⇩⇩⇩⇩⇩⇩⇩⇩⇩⇩⇩⇩             
![Screenshot from 2020-07-16 14-16-14](https://user-images.githubusercontent.com/62067185/87653183-cf84af80-c772-11ea-9e84-f35717221b2c.png)

  
### Preview Link
https://sathsarabandaraj.github.io/sack-site/index.html

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation



