### PR TITLE
Difference between paragraphs in history page

### DIFF
--- a/history/index.html
+++ b/history/index.html
@@ -4,7 +4,8 @@ title: History | St. Anthony's College Kandy
 ---
 
 
-<div class="page-header header-filter header-small" data-parallax="true" style="background-image: url('{{ site.baseurl }}/assets/img/header-image.webp')">
+<div class="page-header header-filter header-small" data-parallax="true"
+  style="background-image: url('{{ site.baseurl }}/assets/img/header-image.webp')">
   <div class="container">
     <div class="row">
       <div class="col-md-8 ml-auto mr-auto">
@@ -124,260 +125,260 @@ title: History | St. Anthony's College Kandy
           The completion of the first fifty years was marked by the first ever schools cricket match involving St.
           Anthony's, which was played in 1904, against Dharmaraja College, with a 109-run victory for the Antonians.
 
-          </p>
 
-          <p text-align="justify">
-            In the year 1906, Fr. Craner was made to relinquish the post of Principal, which he
-            did
-            with a deep sense of sadness, but with a feeling of discipline and obedience, as his services were needed
-            elsewhere.
-            He had already groomed his successor, Fr. D. Philip Caspersz OSB who was already a member of the teaching
-            staff.
-            After Fr. Caspersz assumed duties as Principal, his brother, Fr. James came in as Boarding Prefect. These
-            two
-            brothers, in a comparatively short time changed the status of the school, making it a College. On 20th of
-            December
-            1907, the Annual Distribution of Prizes was held for the first time on a grand scale. The Rt. Revd. Dr. C.
-            Pagnani
-            OSB - Bishop of Kandy was the Chief Guest, and along with Fr. D.A. Pancrazi OSB, he distributed 100 prizes
-            amongst a
-            total student population of 275. The ceremony was held in what was called the "Big College Hall" measuring
-            100'
-            x
-            27'. The programme opened with a rendering of the chorus 'Over the Hill' by the College Choir and ended with
-            chanting of the 'Papal Hymn' and National Anthem. 'Electricity &amp; Magnetism' was introduced as a subject
-            of
-            the
-            'Cambridge Classes' in this year.<br><br>
 
-            &nbsp;Along with Fr. Van Langenberg who was prefect of games, Fr. Philip would spend most evenings
-            encouraging
-            and
-            cheering on his students on the playing field at Barrack Square. The 'Cricket, Hockey &amp; Football Club'
-            (CH&amp;FC) was formed to promote sports at College. St. Anthony's became the first College to play Hockey,
-            in
-            the
-            year 1907. 17 matches were played with 10 of them won, 4 lost and 3 drawn. Amongst the opposition teams were
-            the
-            likes of Indian Rajput Regiment, Colombo Municipality and Bloomfield. Two Football matches were played,
-            winning
-            one
-            and drawing one and five Cricket matches were played winning four and drawing one. The first
-            'Trinity-Antonian'
-            cricket encounter was played in that same year, with the Antonians emerging winners by 14 runs. The irony of
-            it
-            all
-            was that we lost the use of Barrack Square in that year, when debarred by the Military authorities. However,
-            in
-            1908
-            the Kandy Municipal Council granted exclusive use of the Reclamation Grounds for College sports.<br><br>
 
-            The roll of students increased to 300 in 1908. Two pupils secured passes in Senior Division and five in
-            Junior
-            Division 'Cambridge' exams. 'Physiology &amp; Hygiene' was introduced as a subject of the 'Cambridge
-            Classes'.
-            Athletics began to feature prominently in the sports arena, with two Antonian students; D. Vincent Silva and
-            P.M.
-            John, securing first places in the highest class of the Flat Race and the High Jump respectively, in the
-            annual
-            'Empire Day' celebrations held in Kandy on the 2nd of May 1908. The College Sports meet was held on 4th
-            December
-            1908 with a list of events described as follows ; Flat Races, Putting the Shot, Throwing the Cricket Ball,
-            Kicking
-            the Football, Long Jump, Three-legged Race, High Jump, Hockey Dribbling, Egg &amp; Spoon Race, Hurdle Race,
-            Bun-Eating Competition, Quarter Mile Race, Chattie Race, Obstacle Race, Zoo Race and a Thread &amp; Needle
-            Race
-            for
-            Old Boys.<img class="img-thumbnail img-responsive" src="{{ site.baseurl }}/assets/img/Red-Brick.jpg"
-              alt="Red Brick" align="left"><br><br>
+          In the year 1906, Fr. Craner was made to relinquish the post of Principal, which he
+          did
+          with a deep sense of sadness, but with a feeling of discipline and obedience, as his services were needed
+          elsewhere.
+          He had already groomed his successor, Fr. D. Philip Caspersz OSB who was already a member of the teaching
+          staff.
+          After Fr. Caspersz assumed duties as Principal, his brother, Fr. James came in as Boarding Prefect. These
+          two
+          brothers, in a comparatively short time changed the status of the school, making it a College. On 20th of
+          December
+          1907, the Annual Distribution of Prizes was held for the first time on a grand scale. The Rt. Revd. Dr. C.
+          Pagnani
+          OSB - Bishop of Kandy was the Chief Guest, and along with Fr. D.A. Pancrazi OSB, he distributed 100 prizes
+          amongst a
+          total student population of 275. The ceremony was held in what was called the "Big College Hall" measuring
+          100'
+          x
+          27'. The programme opened with a rendering of the chorus 'Over the Hill' by the College Choir and ended with
+          chanting of the 'Papal Hymn' and National Anthem. 'Electricity &amp; Magnetism' was introduced as a subject
+          of
+          the
+          'Cambridge Classes' in this year.<br><br>
 
-            The first ever College publication was released as "St. Anthony's Manual", in 1908, featuring 53 pages of
-            articles
-            and comprehensive reports on all activities of the college. The old red building near the Bishop's Palace
-            was
-            soon
-            replaced by new buildings that came up in quick succession in the area of the coffee store and the old
-            cemetery.<br><br>
+          &nbsp;Along with Fr. Van Langenberg who was prefect of games, Fr. Philip would spend most evenings
+          encouraging
+          and
+          cheering on his students on the playing field at Barrack Square. The 'Cricket, Hockey &amp; Football Club'
+          (CH&amp;FC) was formed to promote sports at College. St. Anthony's became the first College to play Hockey,
+          in
+          the
+          year 1907. 17 matches were played with 10 of them won, 4 lost and 3 drawn. Amongst the opposition teams were
+          the
+          likes of Indian Rajput Regiment, Colombo Municipality and Bloomfield. Two Football matches were played,
+          winning
+          one
+          and drawing one and five Cricket matches were played winning four and drawing one. The first
+          'Trinity-Antonian'
+          cricket encounter was played in that same year, with the Antonians emerging winners by 14 runs. The irony of
+          it
+          all
+          was that we lost the use of Barrack Square in that year, when debarred by the Military authorities. However,
+          in
+          1908
+          the Kandy Municipal Council granted exclusive use of the Reclamation Grounds for College sports.<br><br>
 
-            The year 1909, ended in sadness for the whole school and most of Kandy, when College was robbed of one of
-            its
-            most
-            promising pupils; the little 12-year-old Charlie Hamilton, who had represented the College First XI Teams in
-            Cricket, Football and Hockey with some heroic performances in that year, before his untimely death on
-            5th&nbsp;of
-            November. The newly equipped Physical Laboratory was specially dedicated to the memory of little Charlie
-            Hamilton.<br><br>
+          The roll of students increased to 300 in 1908. Two pupils secured passes in Senior Division and five in
+          Junior
+          Division 'Cambridge' exams. 'Physiology &amp; Hygiene' was introduced as a subject of the 'Cambridge
+          Classes'.
+          Athletics began to feature prominently in the sports arena, with two Antonian students; D. Vincent Silva and
+          P.M.
+          John, securing first places in the highest class of the Flat Race and the High Jump respectively, in the
+          annual
+          'Empire Day' celebrations held in Kandy on the 2nd of May 1908. The College Sports meet was held on 4th
+          December
+          1908 with a list of events described as follows ; Flat Races, Putting the Shot, Throwing the Cricket Ball,
+          Kicking
+          the Football, Long Jump, Three-legged Race, High Jump, Hockey Dribbling, Egg &amp; Spoon Race, Hurdle Race,
+          Bun-Eating Competition, Quarter Mile Race, Chattie Race, Obstacle Race, Zoo Race and a Thread &amp; Needle
+          Race
+          for
+          Old Boys.<img class="img-thumbnail img-responsive" src="{{ site.baseurl }}/assets/img/Red-Brick.jpg"
+            alt="Red Brick" align="left"><br><br>
 
-            In 1910, Fr. Basil Hyde OSB, an old boy of the college who was a member of the staff, at the request of
-            several
-            old
-            boys summoned a meeting on 26th&nbsp;of December 1910 at the College Hall, where the 'First Annual General
-            Meeting'
-            of 'St. Anthony's Old Boys' Association' was held.Very Rev. Fr. Bede Beeckmeyer was elected the first
-            President
-            of
-            the Association proposed by Fr. Hyde himself. In 1912, when Fr. Beeckmeyer was consecrated 'Bishop', Fr.
-            Basil
-            Hyde
-            succeeded him as President of the O.B.A. A total of 152 members had joined the association in its first two
-            years.
-            The first Branch of the O.B.A. was formed on 24thFebruary 1912 as the 'Uva Branch', with Rev. Fr. D.M.Craner
-            OSB
-            elected as President, at a meeting held at St. Mary's, Badulla.<img class="img-thumbnail img-responsive"
-              src="{{ site.baseurl }}/assets/img/history_2_Charlie-Hamilton.jpg" alt="Charlie Hamilton"
-              id="ContentPlaceHolder1_Image8" align="right"><br><br>
+          The first ever College publication was released as "St. Anthony's Manual", in 1908, featuring 53 pages of
+          articles
+          and comprehensive reports on all activities of the college. The old red building near the Bishop's Palace
+          was
+          soon
+          replaced by new buildings that came up in quick succession in the area of the coffee store and the old
+          cemetery.<br><br>
 
-            In 1911, St. Anthony's College played its first inter-collegiate Football match, beating Kingswood College
-            by
-            two
-            goals to nil. Boxing was introduced to St. Anthony's around 1914, at the same time that Royal, Wesley,
-            Trinity
-            and
-            St. Thomas' took to the sport. The first ever Boxing Tournament in the Island was conducted in 1914, for the
-            'Stubbs
-            Shield', and St. Anthony's was amongst the teams that participated.<br>
+          The year 1909, ended in sadness for the whole school and most of Kandy, when College was robbed of one of
+          its
+          most
+          promising pupils; the little 12-year-old Charlie Hamilton, who had represented the College First XI Teams in
+          Cricket, Football and Hockey with some heroic performances in that year, before his untimely death on
+          5th&nbsp;of
+          November. The newly equipped Physical Laboratory was specially dedicated to the memory of little Charlie
+          Hamilton.<br><br>
 
-            Due to ill health, Fr. Philip Caspersz, who had been Principal for nearly a decade, was shifted to hibernate
-            within
-            the monastic walls of reclusion, and a younger man in the person of Fr. Basil Hyde, served as Principal
-            during
-            1915,
-            until a more permanent appointment was made.<br>
+          In 1910, Fr. Basil Hyde OSB, an old boy of the college who was a member of the staff, at the request of
+          several
+          old
+          boys summoned a meeting on 26th&nbsp;of December 1910 at the College Hall, where the 'First Annual General
+          Meeting'
+          of 'St. Anthony's Old Boys' Association' was held.Very Rev. Fr. Bede Beeckmeyer was elected the first
+          President
+          of
+          the Association proposed by Fr. Hyde himself. In 1912, when Fr. Beeckmeyer was consecrated 'Bishop', Fr.
+          Basil
+          Hyde
+          succeeded him as President of the O.B.A. A total of 152 members had joined the association in its first two
+          years.
+          The first Branch of the O.B.A. was formed on 24thFebruary 1912 as the 'Uva Branch', with Rev. Fr. D.M.Craner
+          OSB
+          elected as President, at a meeting held at St. Mary's, Badulla.<img class="img-thumbnail img-responsive"
+            src="{{ site.baseurl }}/assets/img/history_2_Charlie-Hamilton.jpg" alt="Charlie Hamilton"
+            id="ContentPlaceHolder1_Image8" align="right"><br><br>
 
-            In November 1915, at the close of Fr. Basil Hyde's temporary tenure of office, Fr. James Caspersz OSB, whose
-            association with the college began as Art Master before his ordination in 1906, was appointed Principal. He
-            immediately engaged in the expansion of the College by meeting the long felt need for better and spacious
-            accommodation. In October 1916 a new wing of the College was declared open by Mr. E.B.Denham, Director of
-            Education,
-            thus providing adequate laboratory facilities<br><br><img class="img-thumbnail img-responsive"
-              src="{{ site.baseurl }}/assets/img/history_2_Senior-Division-Boarders-1909.jpg"
-              alt="Senior Division Boarders-1909" id="ContentPlaceHolder1_Image3" align="left">
+          In 1911, St. Anthony's College played its first inter-collegiate Football match, beating Kingswood College
+          by
+          two
+          goals to nil. Boxing was introduced to St. Anthony's around 1914, at the same time that Royal, Wesley,
+          Trinity
+          and
+          St. Thomas' took to the sport. The first ever Boxing Tournament in the Island was conducted in 1914, for the
+          'Stubbs
+          Shield', and St. Anthony's was amongst the teams that participated.<br>
 
-            In November 1915, at the close of Fr. Basil Hyde's temporary tenure of office, Fr. James Caspersz OSB, whose
-            association with the college began as Art Master before his ordination in 1906, was appointed Principal. He
-            immediately engaged in the expansion of the College by meeting the long felt need for better and spacious
-            accommodation. In October 1916 a new wing of the College was declared open by Mr. E.B.Denham, Director of
-            Education,
-            thus providing adequate laboratory facilities for Chemistry and Physics. In 1917, the Department of
-            Education
-            officially recognized St. Anthony's College as a 'Fully Organized Secondary School'. An Infants Department
-            for
-            children aged 3-6 years was inaugurated.<img class="img-responsive"
-              src="{{ site.baseurl }}/assets/img/history_2_William-Gopallawa.jpg" alt="William gopallawa" align="right"
-              id="ContentPlaceHolder1_Image10">The 'Prize Giving Day' was held on 15th December 1917, after a lapse of
-            three
-            years due the 1st world war, with the Honourable Chief Justice Sir Alex Wood Renton, presiding. Mr. William
-            Gopallawa, the last Governor General of Ceylon and first President of Sri Lanka, was among the students who
-            successfully completed the London Matriculation Examination during this year. The first telephone was
-            installed
-            in
-            College during that year.<br><br>
+          Due to ill health, Fr. Philip Caspersz, who had been Principal for nearly a decade, was shifted to hibernate
+          within
+          the monastic walls of reclusion, and a younger man in the person of Fr. Basil Hyde, served as Principal
+          during
+          1915,
+          until a more permanent appointment was made.<br>
 
-            The highlight of his term of office was the College's performance in the field of sport. Being a
-            stouthearted
-            sportsman himself, he chose to infuse in his lads the truest type of sporting spirit viz; Win or Lose it's
-            how
-            you
-            play the game that matters. Consequently, in Boxing (the straight lefts), Cricket (the record breaking Jack
-            Anderson) and Cadetting (the De Soysa Cup), the College achieved success and recognition.<br><br>
+          In November 1915, at the close of Fr. Basil Hyde's temporary tenure of office, Fr. James Caspersz OSB, whose
+          association with the college began as Art Master before his ordination in 1906, was appointed Principal. He
+          immediately engaged in the expansion of the College by meeting the long felt need for better and spacious
+          accommodation. In October 1916 a new wing of the College was declared open by Mr. E.B.Denham, Director of
+          Education,
+          thus providing adequate laboratory facilities<br><br><img class="img-thumbnail img-responsive"
+            src="{{ site.baseurl }}/assets/img/history_2_Senior-Division-Boarders-1909.jpg"
+            alt="Senior Division Boarders-1909" id="ContentPlaceHolder1_Image3" align="left">
 
-            <img class="img-responsive img-thumbnail" src="{{ site.baseurl }}/assets/img/history_2_Jack-Anderson.jpg"
-              alt="Jack Anderson" id="ContentPlaceHolder1_Image9" align="left">
-            However, for all the achievements of this era, the one that has stood the time-of-test is the individual
-            score
-            of
-            291 runs by the legendary Jack Anderson, in a match against St. Thomas' College Mount Lavinia, played at
-            Colombo
-            in
-            1918. This remains to date the highest individual score in school cricket. He also scored five centuries in
-            five
-            successive matches and was the first to score a century at what is now the International Cricket Stadium at
-            Asgiriya, besides also being the first to score a century against St. Thomas'. In Boxing, St. Anthony's who
-            were
-            runners-up in the much coveted Stubbs' Shield Competition on two previous occasions, won the trophy for the
-            first
-            time in 1918.Thanks to the likes of Robert Wright, L.V. Jayaweera, N.H. Keerthiratne and the many other
-            Boxers
-            produced during this era, the Antonians remained a formidable force through the 1920's. Though Cadetting had
-            been
-            introduced to St. Anthony's in 1912, it was not until 1916/1917 that our Cadets were able to make an
-            impression
-            at
-            the annual Inter-School Cadet Competitions in Colombo, for the handsome 'De Soysa Cup'.<br><br>
+          In November 1915, at the close of Fr. Basil Hyde's temporary tenure of office, Fr. James Caspersz OSB, whose
+          association with the college began as Art Master before his ordination in 1906, was appointed Principal. He
+          immediately engaged in the expansion of the College by meeting the long felt need for better and spacious
+          accommodation. In October 1916 a new wing of the College was declared open by Mr. E.B.Denham, Director of
+          Education,
+          thus providing adequate laboratory facilities for Chemistry and Physics. In 1917, the Department of
+          Education
+          officially recognized St. Anthony's College as a 'Fully Organized Secondary School'. An Infants Department
+          for
+          children aged 3-6 years was inaugurated.<img class="img-responsive"
+            src="{{ site.baseurl }}/assets/img/history_2_William-Gopallawa.jpg" alt="William gopallawa" align="right"
+            id="ContentPlaceHolder1_Image10">The 'Prize Giving Day' was held on 15th December 1917, after a lapse of
+          three
+          years due the 1st world war, with the Honourable Chief Justice Sir Alex Wood Renton, presiding. Mr. William
+          Gopallawa, the last Governor General of Ceylon and first President of Sri Lanka, was among the students who
+          successfully completed the London Matriculation Examination during this year. The first telephone was
+          installed
+          in
+          College during that year.<br><br>
 
-            In May 1921, Fr. D. Lawrence Hyde OSB succeeded Fr. James Caspersz as Principal of St. Anthony's, and his
-            administration reflected the energizing spirit of his strong personality, to open new vistas in the history
-            of
-            the
-            College. By this time the premises next to the Cathedral had been fully developed with the student
-            population
-            topping one thousand. Several representations were made for the transfer of St. Anthony's from the cramped
-            precincts
-            to more spacious grounds, but to no avail. Finally, it was in 1927 that Bishop Bede Beeckmeyer, an old
-            Antonian
-            himself, purchased the old 'Dunuwille Walauwa', the present premises. The site was eminently suitable and
-            the
-            beauty
-            of the surrounding scenery certainly enhanced it. The river, all along one side of the site, views of
-            Hunnasgiriya
-            and Hantane on two sides and wide stretches of smiling open country on all sides.<br><br>
+          The highlight of his term of office was the College's performance in the field of sport. Being a
+          stouthearted
+          sportsman himself, he chose to infuse in his lads the truest type of sporting spirit viz; Win or Lose it's
+          how
+          you
+          play the game that matters. Consequently, in Boxing (the straight lefts), Cricket (the record breaking Jack
+          Anderson) and Cadetting (the De Soysa Cup), the College achieved success and recognition.<br><br>
 
-            The plague hit Kandy by the end of 1927 and Fr. Hyde obtained the Bishop's permission to shift at least the
-            junior
-            boarders out of Kandy to Katugastota. The renovating and reconditioning of the new premises thus began in
-            November
-            1927. A mass of kitchens and stables had to be turned into dormitories, dining halls and common rooms. With
-            drains
-            all around, outer walls had to be bound to the grounds, the inner walls removed and replaced by pillars and
-            the
-            roof
-            supported by trusses - a combined feat of engineering no modern engineer would attempt. Thanks to Bro.
-            Lysons
-            and
-            the lab-boy William, water service was installed and Titus lamps provided the lighting. The classes were
-            housed
-            in a
-            shed made of coconut pillars, mango rafters, corrugated iron roof and wattle-and-daub dwarf walls<img
-              class="img-responsive img-thumbnail" src="{{ site.baseurl }}/assets/img/history_2_Bishop-Bede.jpg"
-              alt="Bishop Bede" align="right" id="ContentPlaceHolder1_Image11"><br><br>
+          <img class="img-responsive img-thumbnail" src="{{ site.baseurl }}/assets/img/history_2_Jack-Anderson.jpg"
+            alt="Jack Anderson" id="ContentPlaceHolder1_Image9" align="left">
+          However, for all the achievements of this era, the one that has stood the time-of-test is the individual
+          score
+          of
+          291 runs by the legendary Jack Anderson, in a match against St. Thomas' College Mount Lavinia, played at
+          Colombo
+          in
+          1918. This remains to date the highest individual score in school cricket. He also scored five centuries in
+          five
+          successive matches and was the first to score a century at what is now the International Cricket Stadium at
+          Asgiriya, besides also being the first to score a century against St. Thomas'. In Boxing, St. Anthony's who
+          were
+          runners-up in the much coveted Stubbs' Shield Competition on two previous occasions, won the trophy for the
+          first
+          time in 1918.Thanks to the likes of Robert Wright, L.V. Jayaweera, N.H. Keerthiratne and the many other
+          Boxers
+          produced during this era, the Antonians remained a formidable force through the 1920's. Though Cadetting had
+          been
+          introduced to St. Anthony's in 1912, it was not until 1916/1917 that our Cadets were able to make an
+          impression
+          at
+          the annual Inter-School Cadet Competitions in Colombo, for the handsome 'De Soysa Cup'.<br><br>
 
-            On 16th January 1928, the junior boarders were installed at Katugastota with a solemn planting of trees to
-            commemorate the event. The verandah of the old walauwa served as a chapel. Odds and ends served as an altar
-            until
-            one was made on 29th January and the place was consecrated to the sacred heart of Jesus. Fr. Principal
-            himself
-            occupied a room between the kindergarten and the study hall.<br>
-            Fr. Lawrence Hyde built a formidable team of pioneers - Mr. P.B.A.Weerakoon, Bro. Columban Macky, Bro.
-            Joseph,
-            Bro.
-            Lysons and Bro. Timothy - to set about his vision of transformation that today seems unbelievable. Fr. D.D.
-            Barsenbach OSB who was appointed Director of Boarders in 1937 complemented this team. Classes were started
-            for
-            the
-            boarders and others who cared to come over.<br>
-            Two lads came all the way past the Kandy school to be in the temporary classes and to share in the spirit of
-            the
-            new
-            St. Anthony's College, which was rising phoenix-like out of the ashes of the old. During the first few years
-            the
-            school held classes for Kindergarten up to Cambridge Junior, with an approximate staff of around twelve,
-            gradually
-            increasing the range to the London Matriculation and an Inter-Arts form.<br>
-            In 1929, Fr. Hyde had the first permanent set of open classrooms erected alongside the river, which today
-            houses
-            the
-            primary school. It was here, that in 1934, St. Anthony's obtained the best results in the British Empire
-            with
-            100%
-            passes in the London Matriculation Examination. Twelve candidates were presented for the Examination and all
-            passed.
-            Healthy rivalry was enjoyed by the Katugastota boys with their counterparts from the Kandy school in the
-            matter
-            of
-            success at the Examinations, and more often than not, the Kandy youngsters had to congratulate the
-            Katugastota
-            lads
-            on their performance.<br><br>
+          In May 1921, Fr. D. Lawrence Hyde OSB succeeded Fr. James Caspersz as Principal of St. Anthony's, and his
+          administration reflected the energizing spirit of his strong personality, to open new vistas in the history
+          of
+          the
+          College. By this time the premises next to the Cathedral had been fully developed with the student
+          population
+          topping one thousand. Several representations were made for the transfer of St. Anthony's from the cramped
+          precincts
+          to more spacious grounds, but to no avail. Finally, it was in 1927 that Bishop Bede Beeckmeyer, an old
+          Antonian
+          himself, purchased the old 'Dunuwille Walauwa', the present premises. The site was eminently suitable and
+          the
+          beauty
+          of the surrounding scenery certainly enhanced it. The river, all along one side of the site, views of
+          Hunnasgiriya
+          and Hantane on two sides and wide stretches of smiling open country on all sides.<br><br>
+
+          The plague hit Kandy by the end of 1927 and Fr. Hyde obtained the Bishop's permission to shift at least the
+          junior
+          boarders out of Kandy to Katugastota. The renovating and reconditioning of the new premises thus began in
+          November
+          1927. A mass of kitchens and stables had to be turned into dormitories, dining halls and common rooms. With
+          drains
+          all around, outer walls had to be bound to the grounds, the inner walls removed and replaced by pillars and
+          the
+          roof
+          supported by trusses - a combined feat of engineering no modern engineer would attempt. Thanks to Bro.
+          Lysons
+          and
+          the lab-boy William, water service was installed and Titus lamps provided the lighting. The classes were
+          housed
+          in a
+          shed made of coconut pillars, mango rafters, corrugated iron roof and wattle-and-daub dwarf walls<img
+            class="img-responsive img-thumbnail" src="{{ site.baseurl }}/assets/img/history_2_Bishop-Bede.jpg"
+            alt="Bishop Bede" align="right" id="ContentPlaceHolder1_Image11"><br><br>
+
+          On 16th January 1928, the junior boarders were installed at Katugastota with a solemn planting of trees to
+          commemorate the event. The verandah of the old walauwa served as a chapel. Odds and ends served as an altar
+          until
+          one was made on 29th January and the place was consecrated to the sacred heart of Jesus. Fr. Principal
+          himself
+          occupied a room between the kindergarten and the study hall.<br>
+          Fr. Lawrence Hyde built a formidable team of pioneers - Mr. P.B.A.Weerakoon, Bro. Columban Macky, Bro.
+          Joseph,
+          Bro.
+          Lysons and Bro. Timothy - to set about his vision of transformation that today seems unbelievable. Fr. D.D.
+          Barsenbach OSB who was appointed Director of Boarders in 1937 complemented this team. Classes were started
+          for
+          the
+          boarders and others who cared to come over.<br>
+          Two lads came all the way past the Kandy school to be in the temporary classes and to share in the spirit of
+          the
+          new
+          St. Anthony's College, which was rising phoenix-like out of the ashes of the old. During the first few years
+          the
+          school held classes for Kindergarten up to Cambridge Junior, with an approximate staff of around twelve,
+          gradually
+          increasing the range to the London Matriculation and an Inter-Arts form.<br>
+          In 1929, Fr. Hyde had the first permanent set of open classrooms erected alongside the river, which today
+          houses
+          the
+          primary school. It was here, that in 1934, St. Anthony's obtained the best results in the British Empire
+          with
+          100%
+          passes in the London Matriculation Examination. Twelve candidates were presented for the Examination and all
+          passed.
+          Healthy rivalry was enjoyed by the Katugastota boys with their counterparts from the Kandy school in the
+          matter
+          of
+          success at the Examinations, and more often than not, the Kandy youngsters had to congratulate the
+          Katugastota
+          lads
+          on their performance.<br><br>
           <div class="row">
             <div class="col-md-4">
               <img class="img-thumbnail img-responsive"
@@ -491,265 +492,265 @@ title: History | St. Anthony's College Kandy
           mediums
           for all subjects from Grade 1 to University Entrance.
 
-          </p>
-
-          <p text-align="justify"><span class="dropcap">T</span>he Antonian cricket teams of subsequent years,
-            produced some of the most exciting school boy cricketers with young Wijepala Premaratne
-            being adjudged the very first 'All Ceylon School Boy Cricketer' in the year 1956. St.
-            Anthony's College also introduced Rugby Football to its list of sports in 1956, with Bruce
-            Winter captaining the first team. <br><br>
-
-            &nbsp;<span class="img-box">The Centenary Hall was blessed by the Rt. Rev. Dom Bernard <img
-                class="img-thumbnail img-responsive" src="{{ site.baseurl }}/assets/img/history_3_Cricket-Team-1958.jpg"
-                alt="Cricket Team 1958 " align="left" id="ContentPlaceHolder1_Image2">Regno, OSB, Bishop of Kandy and
-              declared open by the Rt. Hon. Sir Oliver Goonetilleke, C.M.E. Governor General of
-              Ceylon, on the 5th September 1957. On the 11th Fr. Hilarion Rudolph, a Graduate of the
-              University of Oxford, came to St.Anthony's as the Principal in 1957, having to succeed a
-              Principal of the caliber of Fr.Rosati, whose early demise at the height of his career
-              spread a veil of emotionalism in the college. He did good work for the school
-              maintaining the high standards the College had already reached. In 1959, the Primary
-              School and the Rainbow Cottages lost the services of an able leader in Fr. Leo
-              Nanayakkara, who was ordained Bishop of Kandy.</span><br><br>
-
-            In 1961, Fr. Rudolph handed over the reins to Fr. D. I. Robinson OSB, who was at the time
-            Warden of the "Mansion" boarding and also Teacher of English. It was during this time that
-            the school's takeover was announced. After much heartburn, the government finally permitted
-            the College to continue, but non-fee levying. This was a period of great hardship, overcome
-            in large measure by the support of the old boys.<br><br>
 
 
-            <img class="img-thumbnail img-responsive"
-              src="{{ site.baseurl }}/assets/img/history_3_Ranjith-Samarasekara.jpg" alt="Ranjith Samarasekara"
-              width="248" height="247" id="ContentPlaceHolder1_Image3" align="left">
-            &nbsp; &nbsp;
-            <img class="img-thumbnail img-responsive" src="{{ site.baseurl }}/assets/img/history_3_Charlie-Joseph.jpg"
-              alt="Charlie Joseph" id="ContentPlaceHolder1_Image10" align="left">
-            &nbsp;
-            <img class="img-thumbnail img-responsive" src="{{ site.baseurl }}/assets/img/history_3_Cyril-Brown.jpg"
-              alt="Cyril Brown" width="165" height="214" id="ContentPlaceHolder1_Image4" align="right">
+          <span class="dropcap">T</span>he Antonian cricket teams of subsequent years,
+          produced some of the most exciting school boy cricketers with young Wijepala Premaratne
+          being adjudged the very first 'All Ceylon School Boy Cricketer' in the year 1956. St.
+          Anthony's College also introduced Rugby Football to its list of sports in 1956, with Bruce
+          Winter captaining the first team. <br><br>
 
-            <br><br>Many were the instances when Fr. Robinson accompanied by Mr. Victor Perera,
-            President of the O.B.A. and later Judge of the Supreme Court, had to visit Old boys, parents
-            and well-wishers for donations to keep the College functioning. In spite of these
-            adversities, studies and sports continued to maintain high standards during this time. The
-            Island wide reputation St. Anthony's enjoyed as a provider of top-drawer sportsmen was
-            maintained with Charlie Joseph, a stylish batsman, being selected as 'School Boy Cricketer'
-            for two consecutive years.<br><br>
+          &nbsp;<span class="img-box">The Centenary Hall was blessed by the Rt. Rev. Dom Bernard <img
+              class="img-thumbnail img-responsive" src="{{ site.baseurl }}/assets/img/history_3_Cricket-Team-1958.jpg"
+              alt="Cricket Team 1958 " align="left" id="ContentPlaceHolder1_Image2">Regno, OSB, Bishop of Kandy and
+            declared open by the Rt. Hon. Sir Oliver Goonetilleke, C.M.E. Governor General of
+            Ceylon, on the 5th September 1957. On the 11th Fr. Hilarion Rudolph, a Graduate of the
+            University of Oxford, came to St.Anthony's as the Principal in 1957, having to succeed a
+            Principal of the caliber of Fr.Rosati, whose early demise at the height of his career
+            spread a veil of emotionalism in the college. He did good work for the school
+            maintaining the high standards the College had already reached. In 1959, the Primary
+            School and the Rainbow Cottages lost the services of an able leader in Fr. Leo
+            Nanayakkara, who was ordained Bishop of Kandy.</span><br><br>
 
-            &nbsp; The College Choir, ably trained and led by Mr. Cyril Brown, also brought many
-            trophies to the College mantle. Fr. Robinson also had the support of several other
-            Benedictine Priests in Fr. Valentine, Fr. Thomas and Fr. Lanfranc, in running the Boarding,
-            which by that time had attracted over 500 students from all parts of the Island, including a
-            sizeable number from Colombo.<br><br>
+          In 1961, Fr. Rudolph handed over the reins to Fr. D. I. Robinson OSB, who was at the time
+          Warden of the "Mansion" boarding and also Teacher of English. It was during this time that
+          the school's takeover was announced. After much heartburn, the government finally permitted
+          the College to continue, but non-fee levying. This was a period of great hardship, overcome
+          in large measure by the support of the old boys.<br><br>
 
-            &nbsp;In 1967, an Old Antonian, Fr. Aidan de Silva OSB was appointed Principal in succession
-            to Fr. Robinson. Hard-pressed by the restrictions imposed upon the College as a non-fee
-            levying institution, he organized a donation of five years for each new admission to school,
-            thus enabling an input of funds. Besides giving the school buildings a complete repair, he
-            built the swimming pool, a new Math Laboratory and six modern classrooms. He organized the
-            Colours Night on an annual basis commencing 1967 to honour the College sportsmen. Based on a
-            suggestion made by Fr. Aidan, the President of the OBA, Mr. R. Victor Perera, launched a
-            'Turf Pitch Fund' with his own generous contribution of a Thousand Rupees, at the first
-            Central Council meeting of the OBA after the Big Match of 1969. The Turf Pitch was
-            completed, blessed by Rt. Rev. Lord Abbot Dom Pio Federici OSB and declared open on the
-            30th&nbsp;January 1970 with Fr. Aidan facing the first ball bowled by Mr. Victor Perera.<img
-              class="img-thumbnail img-responsive"
-              src="{{ site.baseurl }}/assets/img/history_3_1500m-Event-1967-Sport-Meet.jpg"
-              alt="1500m Event-1967 Sport meet" align="right" id="ContentPlaceHolder1_Image6"><br><br>
 
-            The College Swimming Pool was built during his time and St. Anthony's also excelled in
-            Basketball and Tennis, with College producing the best Tennis doubles pair among the
-            schools. He was also instrumental in launching the Christmas Carols and Easter programmes
-            which were much looked forward to events. During this period, the College Choir was invited
-            to perform in a SLBC programme, which was an honour for any College Choir at that time. Fr.
-            Aidan was also instrumental in recommencing the regular publication of 'The Antonian'
-            magazine.&nbsp;Between the 50's and the 70's, St. Anthony's College had a well-established
-            hostel, with over 500 boarders, who came from all parts of the Island. They were spread
-            among 14 cottage type dormitories, arranged in succession, according to age groups. The
-            hostel was supported by a livestock farm, bakery and a fully equipped sickroom, to cater to
-            the needs of the boarders. During this period, the kitchen and refectory at St. Anthony's
-            College was the envy of all visiting school teams, who, to this day, talk about the
-            sumptuous meals they enjoyed at St. Anthony's.<br><br>
+          <img class="img-thumbnail img-responsive"
+            src="{{ site.baseurl }}/assets/img/history_3_Ranjith-Samarasekara.jpg" alt="Ranjith Samarasekara"
+            width="248" height="247" id="ContentPlaceHolder1_Image3" align="left">
+          &nbsp; &nbsp;
+          <img class="img-thumbnail img-responsive" src="{{ site.baseurl }}/assets/img/history_3_Charlie-Joseph.jpg"
+            alt="Charlie Joseph" id="ContentPlaceHolder1_Image10" align="left">
+          &nbsp;
+          <img class="img-thumbnail img-responsive" src="{{ site.baseurl }}/assets/img/history_3_Cyril-Brown.jpg"
+            alt="Cyril Brown" width="165" height="214" id="ContentPlaceHolder1_Image4" align="right">
 
-            &nbsp; The unfortunate incident that took place in 1977 changed the identity / status of St.
-            Anthony's College Kandy, when the school was handed over to the government by the then
-            Bishop of Kandy. In 1977, Fr. Aidan de Silva retired and Fr. Lanfranc Amerasinghe OSB, who
-            was warden of hostels took over as the Principal. He had to struggle hard to keep the school
-            running as a government institution. He emerged unscathed and handed over the reins of the
-            college in 1979 to Fr. Stephen Abraham OSB who had to manage the school with limited
-            resources. The hostel was run independent of the school, by the Benedictine Fathers, who
-            also had the income generating sections - the hall, the swimming pool and the tuck shop -
-            under their jurisdiction. This bifurcation made it difficult for the new Director-managed
-            College to survive, minus all its wonted resources. The facility fees of Rs.5/- per student,
-            was all it got.<img class="img-thumbnail img-responsive"
-              src="{{ site.baseurl }}/assets/img/history_3_Rohan-Wijesinghe.jpg" alt="Rohan Wijesinghe" align="right"
-              id="ContentPlaceHolder1_Image11"><br><br>
+          <br><br>Many were the instances when Fr. Robinson accompanied by Mr. Victor Perera,
+          President of the O.B.A. and later Judge of the Supreme Court, had to visit Old boys, parents
+          and well-wishers for donations to keep the College functioning. In spite of these
+          adversities, studies and sports continued to maintain high standards during this time. The
+          Island wide reputation St. Anthony's enjoyed as a provider of top-drawer sportsmen was
+          maintained with Charlie Joseph, a stylish batsman, being selected as 'School Boy Cricketer'
+          for two consecutive years.<br><br>
 
-            &nbsp;What Fr. Stephen did do under the circumstances was remarkable. His enthusiasm made
-            Hon. R. Premadasa, Prime Minister at the time, donate a two-story block of classrooms, which
-            forms one wing of the school and is called the "Premadasa Block". Most of all, he earned the
-            fullest cooperation of the old boys to support his bid to elevate the college as a most
-            prestigious centre of education, not only in the central province but also in the
-            country.<br><br>
+          &nbsp; The College Choir, ably trained and led by Mr. Cyril Brown, also brought many
+          trophies to the College mantle. Fr. Robinson also had the support of several other
+          Benedictine Priests in Fr. Valentine, Fr. Thomas and Fr. Lanfranc, in running the Boarding,
+          which by that time had attracted over 500 students from all parts of the Island, including a
+          sizeable number from Colombo.<br><br>
 
-            1981 was a memorable year for Antonian Cricket, when they beat Trinity in the Big Match for
-            the very first time at the Asgiriya Ground, thus ending what was thought to be a
-            jinx.<br><br>
+          &nbsp;In 1967, an Old Antonian, Fr. Aidan de Silva OSB was appointed Principal in succession
+          to Fr. Robinson. Hard-pressed by the restrictions imposed upon the College as a non-fee
+          levying institution, he organized a donation of five years for each new admission to school,
+          thus enabling an input of funds. Besides giving the school buildings a complete repair, he
+          built the swimming pool, a new Math Laboratory and six modern classrooms. He organized the
+          Colours Night on an annual basis commencing 1967 to honour the College sportsmen. Based on a
+          suggestion made by Fr. Aidan, the President of the OBA, Mr. R. Victor Perera, launched a
+          'Turf Pitch Fund' with his own generous contribution of a Thousand Rupees, at the first
+          Central Council meeting of the OBA after the Big Match of 1969. The Turf Pitch was
+          completed, blessed by Rt. Rev. Lord Abbot Dom Pio Federici OSB and declared open on the
+          30th&nbsp;January 1970 with Fr. Aidan facing the first ball bowled by Mr. Victor Perera.<img
+            class="img-thumbnail img-responsive"
+            src="{{ site.baseurl }}/assets/img/history_3_1500m-Event-1967-Sport-Meet.jpg"
+            alt="1500m Event-1967 Sport meet" align="right" id="ContentPlaceHolder1_Image6"><br><br>
 
-            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; In 1982 the Colombo branch of the OBA undertook a
-            gigantic task when, under the presidency of the then minister of Power and Energy, K. D. M.
-            C. Bandara, they embarked on a project to develop an Indoor Sports and Pavilion Complex at
-            the Katugastota grounds. However, with the communal troubles the country faced since 1983,
-            raising funds became a difficult task up to about 1989. The project, named "Bishop Leo
-            Nanayakkara Sports and Pavilion Complex", was planned in three stages. The first stage
-            consisting of a gymnasium, badminton and table tennis courts was finally completed in 1991
-            with the help of funds collected by the old boys and Fr. Stephen Abraham. In March 1992 this
-            Sports Complex was officially opened by Mr. K.D.M.C. Bandara and handed over for use by the
-            College.<br>
-            <br>
+          The College Swimming Pool was built during his time and St. Anthony's also excelled in
+          Basketball and Tennis, with College producing the best Tennis doubles pair among the
+          schools. He was also instrumental in launching the Christmas Carols and Easter programmes
+          which were much looked forward to events. During this period, the College Choir was invited
+          to perform in a SLBC programme, which was an honour for any College Choir at that time. Fr.
+          Aidan was also instrumental in recommencing the regular publication of 'The Antonian'
+          magazine.&nbsp;Between the 50's and the 70's, St. Anthony's College had a well-established
+          hostel, with over 500 boarders, who came from all parts of the Island. They were spread
+          among 14 cottage type dormitories, arranged in succession, according to age groups. The
+          hostel was supported by a livestock farm, bakery and a fully equipped sickroom, to cater to
+          the needs of the boarders. During this period, the kitchen and refectory at St. Anthony's
+          College was the envy of all visiting school teams, who, to this day, talk about the
+          sumptuous meals they enjoyed at St. Anthony's.<br><br>
 
-            <img class="img-thumbnail img-responsive"
-              src="{{ site.baseurl }}/assets/img/history_3_Athletic-Team-1978.jpg" alt="Atletic team-1978" align="left"
-              id="ContentPlaceHolder1_Image12"><br><br>
+          &nbsp; The unfortunate incident that took place in 1977 changed the identity / status of St.
+          Anthony's College Kandy, when the school was handed over to the government by the then
+          Bishop of Kandy. In 1977, Fr. Aidan de Silva retired and Fr. Lanfranc Amerasinghe OSB, who
+          was warden of hostels took over as the Principal. He had to struggle hard to keep the school
+          running as a government institution. He emerged unscathed and handed over the reins of the
+          college in 1979 to Fr. Stephen Abraham OSB who had to manage the school with limited
+          resources. The hostel was run independent of the school, by the Benedictine Fathers, who
+          also had the income generating sections - the hall, the swimming pool and the tuck shop -
+          under their jurisdiction. This bifurcation made it difficult for the new Director-managed
+          College to survive, minus all its wonted resources. The facility fees of Rs.5/- per student,
+          was all it got.<img class="img-thumbnail img-responsive"
+            src="{{ site.baseurl }}/assets/img/history_3_Rohan-Wijesinghe.jpg" alt="Rohan Wijesinghe" align="right"
+            id="ContentPlaceHolder1_Image11"><br><br>
 
-            The 'College Diary' was re-introduced in 1987 after a lapse of several years, and has
-            continued to be published annually, ever since, making available the yearly plans of College
-            to the Antonian community. A Public Address system was installed in 1988, effectively
-            enhancing better communication within the vast area of College.<br><br>
+          &nbsp;What Fr. Stephen did do under the circumstances was remarkable. His enthusiasm made
+          Hon. R. Premadasa, Prime Minister at the time, donate a two-story block of classrooms, which
+          forms one wing of the school and is called the "Premadasa Block". Most of all, he earned the
+          fullest cooperation of the old boys to support his bid to elevate the college as a most
+          prestigious centre of education, not only in the central province but also in the
+          country.<br><br>
 
-            The second stage of the project, which consisted of accommodation for visiting teams, a
-            sports pavilion and public stands was named "Jack Anderson Pavilion" after the legendary
-            Antonian cricketer. Fund raising for this stage was spearheaded by Fr. Stephen Abraham and
-            Minister K. D. M. C Bandara. A total sum of around 4 million Rupees was raised in a very
-            short time through donations from parents, old boys, well-wishers and fund raising events
-            such as 'Dances' and 'Coffee Mornings' in Colombo and a carnival in Kandy. This effort
-            enabled the building to take a shell-shape within a period of just four months and was
-            opened by Rev. Fr. Stephen Abraham in March 1993 to commemorate the 75thyear of Jack
-            Anderson's unbroken record of 291 runs in a school match against St. Thomas' College, Mt.
-            Lavinia. Finishing touches were completed on this building in 1993, and has since, been used
-            by the College as its main Pavilion. Work on the third and final stage of the complex
-            commenced in 1994.<img class="img-thumbnail img-responsive"
-              src="{{ site.baseurl }}/assets/img/history_3_Cricket-Team-1991.jpg" alt="Cricket team-1991" align="right"
-              id="ContentPlaceHolder1_Image13"><br> <br>
+          1981 was a memorable year for Antonian Cricket, when they beat Trinity in the Big Match for
+          the very first time at the Asgiriya Ground, thus ending what was thought to be a
+          jinx.<br><br>
 
-            Fr. Stephen Abraham displayed his strength in standing up fearlessly for the principles he
-            believed in, when during the 1988/89 southern revolution, St. Anthony's College became the
-            only government school that did not walk out to revolutionary demands.<br><br>
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; In 1982 the Colombo branch of the OBA undertook a
+          gigantic task when, under the presidency of the then minister of Power and Energy, K. D. M.C.
+          Bandara, they embarked on a project to develop an Indoor Sports and Pavilion Complex at
+          the Katugastota grounds. However, with the communal troubles the country faced since 1983,
+          raising funds became a difficult task up to about 1989. The project, named "Bishop Leo
+          Nanayakkara Sports and Pavilion Complex", was planned in three stages. The first stage
+          consisting of a gymnasium, badminton and table tennis courts was finally completed in 1991
+          with the help of funds collected by the old boys and Fr. Stephen Abraham. In March 1992 this
+          Sports Complex was officially opened by Mr. K.D.M.C. Bandara and handed over for use by the
+          College.<br>
+          <br>
 
-            Other highlights of his stewardship were the Grand School Exhibition in 1979 to mark 125
-            years of the school's existence (1854-1979), which was graced by President J.R. Jayawardena
-            and celebration of 100 continuous years of Benedictine Monks as Principals (1892-1992). On
-            the latter occasion portraits of all past Principals were unveiled in the hall by
-            distinguished persons and thanks offered to God for the innumerable blessings bestowed on
-            the school through the celebration of a special Holy Mass at which the Archbishop of Colombo
-            and the Bishop of Kandy participated.<br><br>
+          <img class="img-thumbnail img-responsive" src="{{ site.baseurl }}/assets/img/history_3_Athletic-Team-1978.jpg"
+            alt="Atletic team-1978" align="left" id="ContentPlaceHolder1_Image12"><br><br>
 
-            In 1989 Fr. Stephen Abraham celebrated his Sacerdotal Silver Jubilee (25 years of
-            Priesthood) by building 25 houses for the minor staff naming the complex "Anthony Gammana"
-            which is a model-housing scheme. His versatility helped the school to achieve high standards
-            of performance in sports such as cricket, rugby, etc. while upholding the traditional
-            excellence in studies for which the College has been well known.<br><br>
+          The 'College Diary' was re-introduced in 1987 after a lapse of several years, and has
+          continued to be published annually, ever since, making available the yearly plans of College
+          to the Antonian community. A Public Address system was installed in 1988, effectively
+          enhancing better communication within the vast area of College.<br><br>
 
-            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The Department of Education in recognition
-            of the success St. Anthony's had achieved under Fr. Stephen Abraham, approved the
-            construction of a new three-storey of buildings at a cost of 8 million rupees, in 1994.<img
-              class="img-thumbnail img-responsive" src="{{ site.baseurl }}/assets/img/history_3_Priyantha-Ekanayaka.jpg"
-              alt="Priyantha Ekanayake" align="left" id="ContentPlaceHolder1_Image14"><br><br>
+          The second stage of the project, which consisted of accommodation for visiting teams, a
+          sports pavilion and public stands was named "Jack Anderson Pavilion" after the legendary
+          Antonian cricketer. Fund raising for this stage was spearheaded by Fr. Stephen Abraham and
+          Minister K. D. M. C Bandara. A total sum of around 4 million Rupees was raised in a very
+          short time through donations from parents, old boys, well-wishers and fund raising events
+          such as 'Dances' and 'Coffee Mornings' in Colombo and a carnival in Kandy. This effort
+          enabled the building to take a shell-shape within a period of just four months and was
+          opened by Rev. Fr. Stephen Abraham in March 1993 to commemorate the 75thyear of Jack
+          Anderson's unbroken record of 291 runs in a school match against St. Thomas' College, Mt.
+          Lavinia. Finishing touches were completed on this building in 1993, and has since, been used
+          by the College as its main Pavilion. Work on the third and final stage of the complex
+          commenced in 1994.<img class="img-thumbnail img-responsive"
+            src="{{ site.baseurl }}/assets/img/history_3_Cricket-Team-1991.jpg" alt="Cricket team-1991" align="right"
+            id="ContentPlaceHolder1_Image13"><br> <br>
 
-            Fr. Abraham, being a firm believer that true character of students could be judged and
-            developed on the playing field and not in the classroom, dedicated much of his time to the
-            numerous sporting activities at college. His encouragement of sports paid rich dividends,
-            particularly in the success the College enjoyed in Cricket, Rugby, Badminton and Table
-            Tennis during the late eighties and early nineties. Many Antonian sportsmen of that era went
-            on to represent National teams, with two in particular, receiving international acclaim.
-            Priyantha Ekanayake who captained the Sri Lanka Rugby Football team for a record ten years,
-            with much success, continues to play a leading role as an administrator and coach at
-            national level. The other of course, is the World's Best Off-Spin Bowler in cricket; Muttiah
-            Muralitharan, who became the highest wicket taker in one day international cricket and in
-            test cricket by breaking Shane Warns world record of 708 wickets<br><br>
+          Fr. Stephen Abraham displayed his strength in standing up fearlessly for the principles he
+          believed in, when during the 1988/89 southern revolution, St. Anthony's College became the
+          only government school that did not walk out to revolutionary demands.<br><br>
 
-            The early and mid nineteen-nineties were some of the best years for sports at St. Anthony's
-            College. The Cricketers won three major awards at the 'Island/Pure Beverages' and six major
-            awards at the 'Bata/Observer' competitions in 1990. Muttiah Muralitharan - "Best Schoolboy
-            Cricketer of the year" &amp; "Best Bowler", Nuwan Kalpage - "Best Captain", and Sajith
-            Fernando - "Best Batsman" were among them. Sajith Fernando was also selected the "Best
-            All-Rounder" at the 'Bata/Observer' ratings in 1991. The greatest moment however was in
-            1993, when three Antonians; Ruwan Kalpage, Muttiah Muralitharan and Piyal Wijetunge were
-            selected to play for Sri Lanka in the first Test Match against South Africa. A fourth
-            Antonian; Sajith Fernando was also in the reckoning but sadly missed out. Mahesh
-            Gunatilleke, Bernard Perera and Marlon Von Haght were the other Antonians to have
-            represented Sri Lanka at Test Cricket in the nineteen-eighties.<img class="img-thumbnail img-responsive"
-              src="{{ site.baseurl }}/assets/img/history_3_Muralidaran.jpg" alt="Muralidaran" align="right"
-              id="ContentPlaceHolder1_Image15"><br><br>
+          Other highlights of his stewardship were the Grand School Exhibition in 1979 to mark 125
+          years of the school's existence (1854-1979), which was graced by President J.R. Jayawardena
+          and celebration of 100 continuous years of Benedictine Monks as Principals (1892-1992). On
+          the latter occasion portraits of all past Principals were unveiled in the hall by
+          distinguished persons and thanks offered to God for the innumerable blessings bestowed on
+          the school through the celebration of a special Holy Mass at which the Archbishop of Colombo
+          and the Bishop of Kandy participated.<br><br>
 
-            The Paddlers, spearheaded by Christopher Arnolda &amp; Umesh de Alwis brought much fame to
-            College. Arnolda was seeded No: 1 and Alwis No: 5 at National level, and both went on to
-            represent Sri Lanka in later years.<br><br>
+          In 1989 Fr. Stephen Abraham celebrated his Sacerdotal Silver Jubilee (25 years of
+          Priesthood) by building 25 houses for the minor staff naming the complex "Anthony Gammana"
+          which is a model-housing scheme. His versatility helped the school to achieve high standards
+          of performance in sports such as cricket, rugby, etc. while upholding the traditional
+          excellence in studies for which the College has been well known.<br><br>
 
-            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The Shuttlers dominated the local schools
-            Badminton tournaments through most of the last decade of the century, with as many as ten
-            Antonians winning National Titles.<br><br>
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The Department of Education in recognition
+          of the success St. Anthony's had achieved under Fr. Stephen Abraham, approved the
+          construction of a new three-storey of buildings at a cost of 8 million rupees, in 1994.<img
+            class="img-thumbnail img-responsive" src="{{ site.baseurl }}/assets/img/history_3_Priyantha-Ekanayaka.jpg"
+            alt="Priyantha Ekanayake" align="left" id="ContentPlaceHolder1_Image14"><br><br>
 
-            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The Ruggerites continued to hold their own
-            against top Rugby Schools, and was a major feeder of quality ruggerites to the local club
-            teams in Kandy &amp; Colombo, with many Antonians going on to represent the Country. The Old
-            Antonians Rugby Football Club has been a major support base ever since their inauguration in
-            the early nineteen-nineties.<br><br>
+          Fr. Abraham, being a firm believer that true character of students could be judged and
+          developed on the playing field and not in the classroom, dedicated much of his time to the
+          numerous sporting activities at college. His encouragement of sports paid rich dividends,
+          particularly in the success the College enjoyed in Cricket, Rugby, Badminton and Table
+          Tennis during the late eighties and early nineties. Many Antonian sportsmen of that era went
+          on to represent National teams, with two in particular, receiving international acclaim.
+          Priyantha Ekanayake who captained the Sri Lanka Rugby Football team for a record ten years,
+          with much success, continues to play a leading role as an administrator and coach at
+          national level. The other of course, is the World's Best Off-Spin Bowler in cricket; Muttiah
+          Muralitharan, who became the highest wicket taker in one day international cricket and in
+          test cricket by breaking Shane Warns world record of 708 wickets<br><br>
 
-            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Having served as Principal for sixteen long
-            years (1979 - 1994), Fr. Stephen Abraham retired, content with what he had achieved for St.
-            Anthony's College Kandy. He was the second longest serving Principal, next to Fr. Lawrence
-            Hyde.<br><br>
+          The early and mid nineteen-nineties were some of the best years for sports at St. Anthony's
+          College. The Cricketers won three major awards at the 'Island/Pure Beverages' and six major
+          awards at the 'Bata/Observer' competitions in 1990. Muttiah Muralitharan - "Best Schoolboy
+          Cricketer of the year" &amp; "Best Bowler", Nuwan Kalpage - "Best Captain", and Sajith
+          Fernando - "Best Batsman" were among them. Sajith Fernando was also selected the "Best
+          All-Rounder" at the 'Bata/Observer' ratings in 1991. The greatest moment however was in
+          1993, when three Antonians; Ruwan Kalpage, Muttiah Muralitharan and Piyal Wijetunge were
+          selected to play for Sri Lanka in the first Test Match against South Africa. A fourth
+          Antonian; Sajith Fernando was also in the reckoning but sadly missed out. Mahesh
+          Gunatilleke, Bernard Perera and Marlon Von Haght were the other Antonians to have
+          represented Sri Lanka at Test Cricket in the nineteen-eighties.<img class="img-thumbnail img-responsive"
+            src="{{ site.baseurl }}/assets/img/history_3_Muralidaran.jpg" alt="Muralidaran" align="right"
+            id="ContentPlaceHolder1_Image15"><br><br>
 
-            Fr. Hilarion Fernando OSB succeeded Fr. Stephen Abraham in April 1994, and completed ten
-            years in the seat on the auspicious occasion of the Sesquicentennial of College. He is also
-            the fifteenth member of the 'Sylvestro Benedictine Order' (OSB) to hold the post, in 112
-            years. Prior to his appointment as Principal, Fr. Hilarion served as Warden of Hostels from
-            1983 - 1991, and as Head Master of the Primary Department from 1990 - 1994.<br><br>
+          The Paddlers, spearheaded by Christopher Arnolda &amp; Umesh de Alwis brought much fame to
+          College. Arnolda was seeded No: 1 and Alwis No: 5 at National level, and both went on to
+          represent Sri Lanka in later years.<br><br>
 
-            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The Old Boys Association Parent Body and
-            Colombo Branch jointly organized a Gala Dinner at the Hotel Suisse - Kandy, on
-            5th&nbsp;November 1994, to bid farewell to Fr. Stephen Abraham and to welcome Fr. Hilarion
-            Fernando.<br><br>
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The Shuttlers dominated the local schools
+          Badminton tournaments through most of the last decade of the century, with as many as ten
+          Antonians winning National Titles.<br><br>
 
-            The OBA (Colombo Branch) published a directory of Old Antonians, titled "Antonian
-            Connection", in 1994. This spiral bound publication was not only a first for Antonians, but
-            also the first of its kind among all schools.<br><br>
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The Ruggerites continued to hold their own
+          against top Rugby Schools, and was a major feeder of quality ruggerites to the local club
+          teams in Kandy &amp; Colombo, with many Antonians going on to represent the Country. The Old
+          Antonians Rugby Football Club has been a major support base ever since their inauguration in
+          the early nineteen-nineties.<br><br>
 
-            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The College Council inaugurated in 1972,
-            functioned continuously as the supreme body of decision making on matters pertaining to
-            College within the frame of rules and regulations of the Department of Education. The
-            Council consists of twelve members at present, headed by Rev. Fr. Principal and including
-            Prefect of Discipline, Prefect of Games, Sectional Heads and Staff Guild President. The
-            Sports Council, which was formed subsequently, continues to govern on all matters relating
-            to sports. Headed by Rev. Fr. Principal, the Council consists of Masters in Charge and
-            Coaches of each sport.<img class="img-thumbnail img-responsive"
-              src="{{ site.baseurl }}/assets/img/history_3_Bishop-Leo-Nanayakkara-Sports-and-Pavilion-Complex.jpg"
-              alt="Bishop Leo Nanayakka Sports &amp; Pavillion Complex" align="left"
-              id="ContentPlaceHolder1_Image16"><br><br>
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Having served as Principal for sixteen long
+          years (1979 - 1994), Fr. Stephen Abraham retired, content with what he had achieved for St.
+          Anthony's College Kandy. He was the second longest serving Principal, next to Fr. Lawrence
+          Hyde.<br><br>
 
-            &nbsp;The third and final stage of the "Bishop Leo Nanayakkara Sports and Pavilion Complex",
-            was completed in 2000, with the Badminton Courts within the complex being upgraded with
-            Air-cushioned flooring in 1999, to accommodate National Tournaments.<br><br>
+          Fr. Hilarion Fernando OSB succeeded Fr. Stephen Abraham in April 1994, and completed ten
+          years in the seat on the auspicious occasion of the Sesquicentennial of College. He is also
+          the fifteenth member of the 'Sylvestro Benedictine Order' (OSB) to hold the post, in 112
+          years. Prior to his appointment as Principal, Fr. Hilarion served as Warden of Hostels from
+          1983 - 1991, and as Head Master of the Primary Department from 1990 - 1994.<br><br>
 
-            The three storeyed block in the upper school was completed in 2001. The "Sesquicentennial
-            Block" of classrooms in the quadrangular was completed with the assistance of parents of the
-            upper school, in 2003. The Primary section too received a new block of four classrooms and a
-            computer laboratory in 2002. Computers and related equipment for the laboratory were
-            obtained through funds collected by parents of the Primary section. A new 'Jubilee Building'
-            was constructed for the Primary in 2003, through the collective efforts of the parents.<img
-              class="img-thumbnail img-responsive"
-              src="{{ site.baseurl }}/assets/img/history_3_New-Three-Story-Building.jpg" alt="New Three Story Building"
-              align="right" id="ContentPlaceHolder1_Image17"><br><br>
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The Old Boys Association Parent Body and
+          Colombo Branch jointly organized a Gala Dinner at the Hotel Suisse - Kandy, on
+          5th&nbsp;November 1994, to bid farewell to Fr. Stephen Abraham and to welcome Fr. Hilarion
+          Fernando.<br><br>
 
-            The student population averaged 2,700, with 2100 in the Sinhala Medium and 600 in the Tamil
-            Medium. The Academic Staff progressively increased with development of curriculum.<br><br>
+          The OBA (Colombo Branch) published a directory of Old Antonians, titled "Antonian
+          Connection",in 1994. This spiral bound publication was not only a first for Antonians, but
+          also the first of its kind among all schools.<br><br>
 
-            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; High standards were maintained in National
-            Examinations with an increase in passes at the G.C.E. (O/L), in Sinhala medium, as well as
-            in Tamil medium. Both mediums have also recorded rapid increases at the G.C.E. (A/L)
-            examinations. Antonian Undergraduates at the Peradeniya University alone, counted over 150
-            in all Faculties, in 2003.<br><br>
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The College Council inaugurated in 1972,
+          functioned continuously as the supreme body of decision making on matters pertaining to
+          College within the frame of rules and regulations of the Department of Education. The
+          Council consists of twelve members at present, headed by Rev. Fr. Principal and including
+          Prefect of Discipline, Prefect of Games, Sectional Heads and Staff Guild President. The
+          Sports Council, which was formed subsequently, continues to govern on all matters relating
+          to sports. Headed by Rev. Fr. Principal, the Council consists of Masters in Charge and
+          Coaches of each sport.<img class="img-thumbnail img-responsive"
+            src="{{ site.baseurl }}/assets/img/history_3_Bishop-Leo-Nanayakkara-Sports-and-Pavilion-Complex.jpg"
+            alt="Bishop Leo Nanayakka Sports &amp; Pavillion Complex" align="left"
+            id="ContentPlaceHolder1_Image16"><br><br>
+
+          &nbsp;The third and final stage of the "Bishop Leo Nanayakkara Sports and Pavilion Complex",
+          was completed in 2000, with the Badminton Courts within the complex being upgraded with
+          Air-cushioned flooring in 1999, to accommodate National Tournaments.<br><br>
+
+          The three storeyed block in the upper school was completed in 2001. The "Sesquicentennial
+          Block" of classrooms in the quadrangular was completed with the assistance of parents of the
+          upper school, in 2003. The Primary section too received a new block of four classrooms and a
+          computer laboratory in 2002. Computers and related equipment for the laboratory were
+          obtained through funds collected by parents of the Primary section. A new 'Jubilee Building'
+          was constructed for the Primary in 2003, through the collective efforts of the parents.<img
+            class="img-thumbnail img-responsive"
+            src="{{ site.baseurl }}/assets/img/history_3_New-Three-Story-Building.jpg" alt="New Three Story Building"
+            align="right" id="ContentPlaceHolder1_Image17"><br><br>
+
+          The student population averaged 2,700, with 2100 in the Sinhala Medium and 600 in the Tamil
+          Medium. The Academic Staff progressively increased with development of curriculum.<br><br>
+
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; High standards were maintained in National
+          Examinations with an increase in passes at the G.C.E. (O/L), in Sinhala medium, as well as
+          in Tamil medium. Both mediums have also recorded rapid increases at the G.C.E. (A/L)
+          examinations. Antonian Undergraduates at the Peradeniya University alone, counted over 150
+          in all Faculties, in 2003.<br><br>
+
           </p>
         </div>
       </div>


### PR DESCRIPTION
Purpose
The purpose of this PR is to fix #259

Goals
Fix the differences between some paragraphs on the history page

Approach
Fixed the differences of paragraphs on the history page

Screenshots
<img width="1279" alt="Screen Shot 2021-10-17 at 7 01 22 AM" src="https://user-images.githubusercontent.com/70457601/137607476-ef0e8be8-7b45-47ba-a1bf-84a2ac739125.png">


Preview Link
https://hasthikagirihagama.github.io/sack-site/