### PR TITLE
Margin added to images on history page

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -372,3 +372,20 @@
   max-width: 800px;
   margin: 40px auto;
 }
+
+/* for history page  */
+.main > .section > .container > #resource-section > .container > img {
+  margin: 20px;
+}
+
+@media only screen and (max-width: 991px) {
+  .main > .section > .container > #resource-section > .container > img {
+    margin: 10px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .main > .section > .container > #resource-section > .container > img {
+    margin: 5px;
+  }
+}

--- a/history/index.html
+++ b/history/index.html
@@ -3,12 +3,6 @@ layout: default
 title: History | St. Anthony's College Kandy
 ---
 
-<style>
-  img {
-    margin: 20px;
-  }
-</style>
-
 <div class="page-header header-filter header-small" data-parallax="true"
   style="background-image: url('{{ site.baseurl }}/assets/img/header-image.webp')">
   <div class="container">


### PR DESCRIPTION
## Purpose
On the history page, there are many images and text are very close to each other.
The purpose of this PR is to fix #264 

## Goals
To add the margin to each image

## Approach
in the css added the margin to the img tag

### Screenshots
![image](https://user-images.githubusercontent.com/50802786/138146482-c1009de4-9890-4b6f-83de-fbd302b4db53.png)
  
### Preview Link
https://killerkc12.github.io/sack-site/history/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Test environment
OS: Windows
Browser : Chrome
Version : latest

## Learning
Learn about margins